### PR TITLE
Add Apache Ignite ticketing PoC skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # Ticket_IGNITE
-Ticket system with Apache Ignite distributed system.
+
+Proof-of-concept ticketing service that uses Apache Ignite as a
+distributed data store.
+
+## Prerequisites
+
+- Java 17+
+- Maven 3+
+
+## Running the application
+
+1. Start the Spring Boot application, which will also start an embedded
+   Ignite node:
+
+   ```bash
+   mvn spring-boot:run
+   ```
+
+2. Reserve a seat by calling the REST endpoint. Example using `curl`:
+
+   ```bash
+   curl -X POST \
+        http://localhost:8080/events/1/seats/1/reserve
+   ```
+
+   On success, the service returns a JSON representation of the created
+   ticket. Attempting to reserve an already-reserved seat or specifying a
+   wrong `eventId` yields an error response.
+
+## Running tests
+
+```bash
+mvn test
+```
+
+The tests cover the reservation service and the REST controller.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.0</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>ticketing-ignite</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>ticketing-ignite</name>
+    <description>Ticket system with Apache Ignite</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-core</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-spring</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/ticketing/TicketingApplication.java
+++ b/src/main/java/com/example/ticketing/TicketingApplication.java
@@ -1,0 +1,11 @@
+package com.example.ticketing;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TicketingApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TicketingApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/ticketing/config/IgniteConfig.java
+++ b/src/main/java/com/example/ticketing/config/IgniteConfig.java
@@ -1,0 +1,19 @@
+package com.example.ticketing.config;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class IgniteConfig {
+
+    @Bean(destroyMethod = "close")
+    public Ignite ignite() {
+        IgniteConfiguration cfg = new IgniteConfiguration();
+        cfg.setIgniteInstanceName("ticketing-ignite");
+        cfg.setPeerClassLoadingEnabled(true);
+        return Ignition.start(cfg);
+    }
+}

--- a/src/main/java/com/example/ticketing/model/Event.java
+++ b/src/main/java/com/example/ticketing/model/Event.java
@@ -1,0 +1,32 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class Event implements Serializable {
+    private Long id;
+    private String name;
+
+    public Event() {
+    }
+
+    public Event(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/ticketing/model/Seat.java
+++ b/src/main/java/com/example/ticketing/model/Seat.java
@@ -1,0 +1,52 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class Seat implements Serializable {
+    private Long id;
+    private Long eventId;
+    private String number;
+    private boolean reserved;
+
+    public Seat() {
+    }
+
+    public Seat(Long id, Long eventId, String number, boolean reserved) {
+        this.id = id;
+        this.eventId = eventId;
+        this.number = number;
+        this.reserved = reserved;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Long eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public boolean isReserved() {
+        return reserved;
+    }
+
+    public void setReserved(boolean reserved) {
+        this.reserved = reserved;
+    }
+}

--- a/src/main/java/com/example/ticketing/model/Ticket.java
+++ b/src/main/java/com/example/ticketing/model/Ticket.java
@@ -1,0 +1,52 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class Ticket implements Serializable {
+    private Long id;
+    private Long eventId;
+    private Long seatId;
+    private String customer;
+
+    public Ticket() {
+    }
+
+    public Ticket(Long id, Long eventId, Long seatId, String customer) {
+        this.id = id;
+        this.eventId = eventId;
+        this.seatId = seatId;
+        this.customer = customer;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Long eventId) {
+        this.eventId = eventId;
+    }
+
+    public Long getSeatId() {
+        return seatId;
+    }
+
+    public void setSeatId(Long seatId) {
+        this.seatId = seatId;
+    }
+
+    public String getCustomer() {
+        return customer;
+    }
+
+    public void setCustomer(String customer) {
+        this.customer = customer;
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/EventRepository.java
+++ b/src/main/java/com/example/ticketing/repository/EventRepository.java
@@ -1,0 +1,24 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.Event;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EventRepository {
+
+    private final IgniteCache<Long, Event> cache;
+
+    public EventRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("events");
+    }
+
+    public void save(Event event) {
+        cache.put(event.getId(), event);
+    }
+
+    public Event findById(Long id) {
+        return cache.get(id);
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/SeatRepository.java
+++ b/src/main/java/com/example/ticketing/repository/SeatRepository.java
@@ -1,0 +1,24 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.Seat;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SeatRepository {
+
+    private final IgniteCache<Long, Seat> cache;
+
+    public SeatRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("seats");
+    }
+
+    public void save(Seat seat) {
+        cache.put(seat.getId(), seat);
+    }
+
+    public Seat findById(Long id) {
+        return cache.get(id);
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/TicketRepository.java
+++ b/src/main/java/com/example/ticketing/repository/TicketRepository.java
@@ -1,0 +1,24 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.Ticket;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class TicketRepository {
+
+    private final IgniteCache<Long, Ticket> cache;
+
+    public TicketRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("tickets");
+    }
+
+    public void save(Ticket ticket) {
+        cache.put(ticket.getId(), ticket);
+    }
+
+    public Ticket findById(Long id) {
+        return cache.get(id);
+    }
+}

--- a/src/main/java/com/example/ticketing/service/ReservationService.java
+++ b/src/main/java/com/example/ticketing/service/ReservationService.java
@@ -1,0 +1,38 @@
+package com.example.ticketing.service;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.repository.SeatRepository;
+import com.example.ticketing.repository.TicketRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class ReservationService {
+
+    private final SeatRepository seatRepository;
+    private final TicketRepository ticketRepository;
+
+    public ReservationService(SeatRepository seatRepository, TicketRepository ticketRepository) {
+        this.seatRepository = seatRepository;
+        this.ticketRepository = ticketRepository;
+    }
+
+    public Ticket reserveSeat(Long eventId, Long seatId, String customer) {
+        Seat seat = seatRepository.findById(seatId);
+        if (seat == null || !seat.getEventId().equals(eventId) || seat.isReserved()) {
+            throw new IllegalStateException("Seat not available");
+        }
+        seat.setReserved(true);
+        seatRepository.save(seat);
+
+        Ticket ticket = new Ticket();
+        ticket.setId(UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE);
+        ticket.setEventId(eventId);
+        ticket.setSeatId(seatId);
+        ticket.setCustomer(customer);
+        ticketRepository.save(ticket);
+        return ticket;
+    }
+}

--- a/src/main/java/com/example/ticketing/web/ReservationController.java
+++ b/src/main/java/com/example/ticketing/web/ReservationController.java
@@ -1,0 +1,25 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.service.ReservationService;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    public ReservationController(ReservationService reservationService) {
+        this.reservationService = reservationService;
+    }
+
+    @PostMapping("/events/{eventId}/seats/{seatId}/reserve")
+    public Ticket reserveSeat(@PathVariable Long eventId,
+                              @PathVariable Long seatId,
+                              @RequestParam String customer) {
+        return reservationService.reserveSeat(eventId, seatId, customer);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.main.banner-mode=off

--- a/src/test/java/com/example/ticketing/TicketingApplicationTests.java
+++ b/src/test/java/com/example/ticketing/TicketingApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.ticketing;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TicketingApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/example/ticketing/service/ReservationServiceTest.java
+++ b/src/test/java/com/example/ticketing/service/ReservationServiceTest.java
@@ -1,0 +1,72 @@
+package com.example.ticketing.service;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.repository.SeatRepository;
+import com.example.ticketing.repository.TicketRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @Mock
+    private SeatRepository seatRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(seatRepository, ticketRepository);
+    }
+
+    @Test
+    void reserveSeatSuccessful() {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        Ticket ticket = reservationService.reserveSeat(1L, 1L, "Alice");
+
+        assertNotNull(ticket.getId());
+        assertEquals(1L, ticket.getEventId());
+        assertEquals(1L, ticket.getSeatId());
+        assertEquals("Alice", ticket.getCustomer());
+
+        ArgumentCaptor<Seat> seatCaptor = ArgumentCaptor.forClass(Seat.class);
+        verify(seatRepository).save(seatCaptor.capture());
+        assertTrue(seatCaptor.getValue().isReserved());
+
+        verify(ticketRepository).save(ticket);
+    }
+
+    @Test
+    void reserveAlreadyReservedSeatThrows() {
+        Seat seat = new Seat(1L, 1L, "A1", true);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        assertThrows(IllegalStateException.class, () -> reservationService.reserveSeat(1L, 1L, "Alice"));
+
+        verify(seatRepository, never()).save(any());
+        verify(ticketRepository, never()).save(any());
+    }
+
+    @Test
+    void reserveSeatWithWrongEventIdThrows() {
+        Seat seat = new Seat(1L, 2L, "A1", false);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        assertThrows(IllegalStateException.class, () -> reservationService.reserveSeat(1L, 1L, "Alice"));
+
+        verify(seatRepository, never()).save(any());
+        verify(ticketRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/example/ticketing/web/ReservationControllerTest.java
+++ b/src/test/java/com/example/ticketing/web/ReservationControllerTest.java
@@ -1,0 +1,49 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.service.ReservationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ReservationController.class)
+class ReservationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReservationService reservationService;
+
+    @Test
+    void reserveSeatReturnsTicket() throws Exception {
+        Ticket ticket = new Ticket(1L, 1L, 1L, "Alice");
+        when(reservationService.reserveSeat(1L, 1L, "Alice")).thenReturn(ticket);
+
+        mockMvc.perform(post("/events/1/seats/1/reserve")
+                .param("customer", "Alice")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventId").value(1L))
+                .andExpect(jsonPath("$.seatId").value(1L))
+                .andExpect(jsonPath("$.customer").value("Alice"));
+    }
+
+    @Test
+    void reserveSeatReturnsError() throws Exception {
+        when(reservationService.reserveSeat(1L, 1L, "Alice"))
+                .thenThrow(new IllegalStateException("Seat not available"));
+
+        mockMvc.perform(post("/events/1/seats/1/reserve")
+                .param("customer", "Alice")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError());
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Spring Boot project with Apache Ignite configuration
- add models for events, seats and tickets with Ignite-backed repositories
- implement reservation service and REST controller for seat reservations
- add unit tests for reservation service and controller
- document prerequisites, run instructions and example REST call in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:ticketing-ignite:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.3.0 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.3.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM @ line 5, column 13)*

------
https://chatgpt.com/codex/tasks/task_e_68961b4f4b04832098acfb1c9b5c2fa9