### PR TITLE
Add startup data initializer and verification test

### DIFF
--- a/src/main/java/com/example/ticketing/config/DataInitializer.java
+++ b/src/main/java/com/example/ticketing/config/DataInitializer.java
@@ -1,0 +1,35 @@
+package com.example.ticketing.config;
+
+import com.example.ticketing.model.Event;
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.repository.EventRepository;
+import com.example.ticketing.repository.SeatRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataInitializer implements CommandLineRunner {
+
+    private final EventRepository eventRepository;
+    private final SeatRepository seatRepository;
+
+    public DataInitializer(EventRepository eventRepository, SeatRepository seatRepository) {
+        this.eventRepository = eventRepository;
+        this.seatRepository = seatRepository;
+    }
+
+    @Override
+    public void run(String... args) {
+        Event event = new Event(1L, "Sample Event");
+        eventRepository.save(event);
+
+        Seat seat = new Seat(1L, event.getId(), "A1", false);
+        seatRepository.save(seat);
+
+        // Verify seeding by fetching the seat
+        Seat fetched = seatRepository.findById(seat.getId());
+        if (fetched != null) {
+            System.out.println("Seeded seat: " + fetched.getNumber() + " for event " + fetched.getEventId());
+        }
+    }
+}

--- a/src/test/java/com/example/ticketing/DataInitializerTest.java
+++ b/src/test/java/com/example/ticketing/DataInitializerTest.java
@@ -1,0 +1,24 @@
+package com.example.ticketing;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.repository.SeatRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class DataInitializerTest {
+
+    @Autowired
+    private SeatRepository seatRepository;
+
+    @Test
+    void seededSeatIsAvailable() {
+        Seat seat = seatRepository.findById(1L);
+        assertNotNull(seat);
+        assertEquals(1L, seat.getEventId());
+        assertEquals("A1", seat.getNumber());
+    }
+}


### PR DESCRIPTION
## Summary
- seed a default event and seat on application startup
- verify seeded seat availability via a Spring Boot test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896d09f113483208721067dfdd924d4