### PR TITLE
Generate seats with nested loops

### DIFF
--- a/src/main/java/com/example/ticketing/config/DataInitializer.java
+++ b/src/main/java/com/example/ticketing/config/DataInitializer.java
@@ -23,7 +23,12 @@ public class DataInitializer {
         Event event = new Event(1L, "Demo Event");
         eventRepository.save(event);
 
-        seatRepository.save(new Seat(1L, 1L, "A1", false));
-        seatRepository.save(new Seat(2L, 1L, "A2", false));
+        long seatId = 1L;
+        for (char row = 'A'; row <= 'J'; row++) {
+            for (int number = 1; number <= 10; number++) {
+                String seatNumber = row + String.valueOf(number);
+                seatRepository.save(new Seat(seatId++, event.getId(), seatNumber, false));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace hard-coded seat initialization with nested loops to generate rows A–J and numbers 1–10 for the demo event.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689846ee76708320ab6171fa2765bbfd