### PR TITLE
Expose seats listing endpoint

### DIFF
--- a/src/main/java/com/example/ticketing/repository/SeatRepository.java
+++ b/src/main/java/com/example/ticketing/repository/SeatRepository.java
@@ -5,6 +5,10 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.springframework.stereotype.Repository;
 
+import javax.cache.Cache;
+import java.util.ArrayList;
+import java.util.List;
+
 @Repository
 public class SeatRepository {
 
@@ -20,5 +24,16 @@ public class SeatRepository {
 
     public Seat findById(Long id) {
         return cache.get(id);
+    }
+
+    public List<Seat> findByEventId(Long eventId) {
+        List<Seat> seats = new ArrayList<>();
+        for (Cache.Entry<Long, Seat> entry : cache) {
+            Seat seat = entry.getValue();
+            if (seat.getEventId().equals(eventId)) {
+                seats.add(seat);
+            }
+        }
+        return seats;
     }
 }

--- a/src/main/java/com/example/ticketing/service/ReservationService.java
+++ b/src/main/java/com/example/ticketing/service/ReservationService.java
@@ -6,6 +6,7 @@ import com.example.ticketing.repository.SeatRepository;
 import com.example.ticketing.repository.TicketRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -42,6 +43,10 @@ public class ReservationService {
             throw new IllegalStateException("Seat not found");
         }
         return seat;
+    }
+
+    public List<Seat> getSeatsByEvent(Long eventId) {
+        return seatRepository.findByEventId(eventId);
     }
 
     public Seat cancelSeat(Long eventId, Long seatId) {

--- a/src/main/java/com/example/ticketing/web/ReservationController.java
+++ b/src/main/java/com/example/ticketing/web/ReservationController.java
@@ -5,6 +5,8 @@ import com.example.ticketing.model.Ticket;
 import com.example.ticketing.service.ReservationService;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
 public class ReservationController {
@@ -26,6 +28,11 @@ public class ReservationController {
     public Seat getSeat(@PathVariable Long eventId,
                         @PathVariable Long seatId) {
         return reservationService.getSeat(eventId, seatId);
+    }
+
+    @GetMapping("/events/{eventId}/seats")
+    public List<Seat> getSeats(@PathVariable Long eventId) {
+        return reservationService.getSeatsByEvent(eventId);
     }
 
     @PostMapping("/events/{eventId}/seats/{seatId}/cancel")

--- a/src/test/java/com/example/ticketing/service/ReservationServiceTest.java
+++ b/src/test/java/com/example/ticketing/service/ReservationServiceTest.java
@@ -11,6 +11,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -93,5 +96,16 @@ class ReservationServiceTest {
 
         verify(seatRepository, never()).save(any());
         verify(ticketRepository, never()).delete(anyLong());
+    }
+
+    @Test
+    void getSeatsByEventReturnsSeats() {
+        List<Seat> seats = Arrays.asList(new Seat(1L, 1L, "A1", false),
+                                         new Seat(2L, 1L, "A2", true));
+        when(seatRepository.findByEventId(1L)).thenReturn(seats);
+
+        List<Seat> result = reservationService.getSeatsByEvent(1L);
+
+        assertEquals(seats, result);
     }
 }

--- a/src/test/java/com/example/ticketing/web/ReservationControllerTest.java
+++ b/src/test/java/com/example/ticketing/web/ReservationControllerTest.java
@@ -10,6 +10,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -76,5 +79,17 @@ class ReservationControllerTest {
 
         mockMvc.perform(post("/events/1/seats/1/cancel"))
                 .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void getSeatsReturnsSeatList() throws Exception {
+        List<Seat> seats = Arrays.asList(new Seat(1L, 1L, "A1", false),
+                                         new Seat(2L, 1L, "A2", true));
+        when(reservationService.getSeatsByEvent(1L)).thenReturn(seats);
+
+        mockMvc.perform(get("/events/1/seats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(1L));
     }
 }


### PR DESCRIPTION
## Summary
- add cache scan in `SeatRepository` to load all seats for an event
- expose `ReservationService.getSeatsByEvent` and map `GET /events/{eventId}/seats`
- cover new functionality with service and controller tests

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68985e23190083209feccd49eb2e4e24