### PR TITLE
Add Apache Ignite ticketing PoC skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,98 @@
 # Ticket_IGNITE
-Ticket system with Apache Ignite distributed system.
+
+Proof-of-concept ticketing service that uses Apache Ignite as a
+distributed data store.
+
+## Tech stack
+
+- Java 17
+- Spring Boot 2.7.18
+- Apache Ignite 2.15
+- REST + JSON
+- HTTP Basic authentication
+- Maven for build
+- JUnit 5 for tests
+
+## Project structure
+
+```text
+ticketing-ignite/
+├── pom.xml
+└── src
+    ├── main/java/com/example/ticketing
+    │   ├── TicketingApplication.java
+    │   ├── config/
+    │   ├── model/
+    │   ├── repository/
+    │   ├── service/
+    │   └── web/
+    └── test/java/com/example/ticketing
+        ├── service/
+        └── web/
+```
+
+## Prerequisites
+
+- Java 17+
+- Maven 3+
+
+## Running the application
+
+1. Start the Spring Boot application, which will also start an embedded
+   Ignite node:
+
+   ```bash
+   mvn spring-boot:run -Dspring-boot.run.jvmArguments="\
+   --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
+   --add-opens=java.base/java.nio=ALL-UNNAMED \
+   --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+   --add-opens=java.base/java.lang=ALL-UNNAMED \
+   --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+   --add-opens=java.base/java.util=ALL-UNNAMED \
+   --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
+   --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
+   --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
+   -Djava.net.preferIPv4Stack=true \
+   -Xms512m -Xmx512m"
+   ```
+
+2. Sample data for one demo event with two seats is loaded at startup. Use
+   the REST endpoints with the default user (`user`/`password`).
+
+   Reserve a seat:
+
+   ```bash
+   curl -u user:password -X POST "http://localhost:8080/events/1/seats/1/reserve"
+   ```
+
+   List your tickets:
+
+   ```bash
+   curl -u user:password "http://localhost:8080/me/tickets"
+   ```
+
+   Cancel a ticket:
+
+   ```bash
+   curl -u user:password -X DELETE "http://localhost:8080/me/tickets/{ticketId}"
+   ```
+
+   On success, the service returns a JSON representation of the seat or
+   ticket. Invalid operations yield an error response.
+
+3. A simple web page is available for manual testing:
+
+   ```
+   http://localhost:8080/index.html
+   ```
+
+   Use the login form first, then manage reservations through the provided
+   forms to reserve seats, view your tickets and cancel them.
+
+## Running tests
+
+```bash
+mvn test
+```
+
+The tests cover the reservation service and the REST controller.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.18</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>ticketing-ignite</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>ticketing-ignite</name>
+    <description>Ticket system with Apache Ignite</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-core</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-spring</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/ticketing/TicketingApplication.java
+++ b/src/main/java/com/example/ticketing/TicketingApplication.java
@@ -1,0 +1,11 @@
+package com.example.ticketing;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TicketingApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TicketingApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/ticketing/config/DataInitializer.java
+++ b/src/main/java/com/example/ticketing/config/DataInitializer.java
@@ -1,0 +1,29 @@
+package com.example.ticketing.config;
+
+import com.example.ticketing.model.Event;
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.repository.EventRepository;
+import com.example.ticketing.repository.SeatRepository;
+import javax.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataInitializer {
+    private final EventRepository eventRepository;
+    private final SeatRepository seatRepository;
+
+    public DataInitializer(EventRepository eventRepository, SeatRepository seatRepository) {
+        this.eventRepository = eventRepository;
+        this.seatRepository = seatRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+        // 注意：如果你的 @Id 是 @GeneratedValue，就不要手動塞 1L 當主鍵
+        Event event = new Event(1L, "Demo Event");
+        eventRepository.save(event);
+
+        seatRepository.save(new Seat(1L, 1L, "A1", false));
+        seatRepository.save(new Seat(2L, 1L, "A2", false));
+    }
+}

--- a/src/main/java/com/example/ticketing/config/IgniteConfig.java
+++ b/src/main/java/com/example/ticketing/config/IgniteConfig.java
@@ -1,0 +1,19 @@
+package com.example.ticketing.config;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class IgniteConfig {
+
+    @Bean(destroyMethod = "close")
+    public Ignite ignite() {
+        IgniteConfiguration cfg = new IgniteConfiguration();
+        cfg.setIgniteInstanceName("ticketing-ignite");
+        cfg.setPeerClassLoadingEnabled(true);
+        return Ignition.start(cfg);
+    }
+}

--- a/src/main/java/com/example/ticketing/config/SecurityConfig.java
+++ b/src/main/java/com/example/ticketing/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.example.ticketing.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeRequests().anyRequest().authenticated()
+            .and().httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService users() {
+        UserDetails user = User.withDefaultPasswordEncoder()
+                .username("user")
+                .password("password")
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+}

--- a/src/main/java/com/example/ticketing/model/Event.java
+++ b/src/main/java/com/example/ticketing/model/Event.java
@@ -1,0 +1,32 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class Event implements Serializable {
+    private Long id;
+    private String name;
+
+    public Event() {
+    }
+
+    public Event(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/ticketing/model/Seat.java
+++ b/src/main/java/com/example/ticketing/model/Seat.java
@@ -1,0 +1,52 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class Seat implements Serializable {
+    private Long id;
+    private Long eventId;
+    private String number;
+    private boolean reserved;
+
+    public Seat() {
+    }
+
+    public Seat(Long id, Long eventId, String number, boolean reserved) {
+        this.id = id;
+        this.eventId = eventId;
+        this.number = number;
+        this.reserved = reserved;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Long eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public boolean isReserved() {
+        return reserved;
+    }
+
+    public void setReserved(boolean reserved) {
+        this.reserved = reserved;
+    }
+}

--- a/src/main/java/com/example/ticketing/model/Ticket.java
+++ b/src/main/java/com/example/ticketing/model/Ticket.java
@@ -1,0 +1,52 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class Ticket implements Serializable {
+    private Long id;
+    private Long eventId;
+    private Long seatId;
+    private String customer;
+
+    public Ticket() {
+    }
+
+    public Ticket(Long id, Long eventId, Long seatId, String customer) {
+        this.id = id;
+        this.eventId = eventId;
+        this.seatId = seatId;
+        this.customer = customer;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Long eventId) {
+        this.eventId = eventId;
+    }
+
+    public Long getSeatId() {
+        return seatId;
+    }
+
+    public void setSeatId(Long seatId) {
+        this.seatId = seatId;
+    }
+
+    public String getCustomer() {
+        return customer;
+    }
+
+    public void setCustomer(String customer) {
+        this.customer = customer;
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/EventRepository.java
+++ b/src/main/java/com/example/ticketing/repository/EventRepository.java
@@ -1,0 +1,24 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.Event;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EventRepository {
+
+    private final IgniteCache<Long, Event> cache;
+
+    public EventRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("events");
+    }
+
+    public void save(Event event) {
+        cache.put(event.getId(), event);
+    }
+
+    public Event findById(Long id) {
+        return cache.get(id);
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/SeatRepository.java
+++ b/src/main/java/com/example/ticketing/repository/SeatRepository.java
@@ -1,0 +1,24 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.Seat;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SeatRepository {
+
+    private final IgniteCache<Long, Seat> cache;
+
+    public SeatRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("seats");
+    }
+
+    public void save(Seat seat) {
+        cache.put(seat.getId(), seat);
+    }
+
+    public Seat findById(Long id) {
+        return cache.get(id);
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/TicketRepository.java
+++ b/src/main/java/com/example/ticketing/repository/TicketRepository.java
@@ -1,0 +1,53 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.Ticket;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.springframework.stereotype.Repository;
+
+import javax.cache.Cache;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class TicketRepository {
+
+    private final IgniteCache<Long, Ticket> cache;
+
+    public TicketRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("tickets");
+    }
+
+    public void save(Ticket ticket) {
+        cache.put(ticket.getId(), ticket);
+    }
+
+    public Ticket findById(Long id) {
+        return cache.get(id);
+    }
+
+    public void delete(Long id) {
+        cache.remove(id);
+    }
+
+    public Ticket findByEventIdAndSeatId(Long eventId, Long seatId) {
+        for (Cache.Entry<Long, Ticket> entry : cache) {
+            Ticket ticket = entry.getValue();
+            if (ticket.getEventId().equals(eventId) && ticket.getSeatId().equals(seatId)) {
+                return ticket;
+            }
+        }
+        return null;
+    }
+
+    public List<Ticket> findByCustomer(String customer) {
+        List<Ticket> tickets = new ArrayList<>();
+        for (Cache.Entry<Long, Ticket> entry : cache) {
+            Ticket ticket = entry.getValue();
+            if (customer.equals(ticket.getCustomer())) {
+                tickets.add(ticket);
+            }
+        }
+        return tickets;
+    }
+}

--- a/src/main/java/com/example/ticketing/service/ReservationService.java
+++ b/src/main/java/com/example/ticketing/service/ReservationService.java
@@ -1,0 +1,78 @@
+package com.example.ticketing.service;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.repository.SeatRepository;
+import com.example.ticketing.repository.TicketRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ReservationService {
+
+    private final SeatRepository seatRepository;
+    private final TicketRepository ticketRepository;
+
+    public ReservationService(SeatRepository seatRepository, TicketRepository ticketRepository) {
+        this.seatRepository = seatRepository;
+        this.ticketRepository = ticketRepository;
+    }
+
+    public Ticket reserveSeat(Long eventId, Long seatId, String customer) {
+        Seat seat = seatRepository.findById(seatId);
+        if (seat == null || !seat.getEventId().equals(eventId) || seat.isReserved()) {
+            throw new IllegalStateException("Seat not available");
+        }
+        seat.setReserved(true);
+        seatRepository.save(seat);
+
+        Ticket ticket = new Ticket();
+        ticket.setId(UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE);
+        ticket.setEventId(eventId);
+        ticket.setSeatId(seatId);
+        ticket.setCustomer(customer);
+        ticketRepository.save(ticket);
+        return ticket;
+    }
+
+    public Seat getSeat(Long eventId, Long seatId) {
+        Seat seat = seatRepository.findById(seatId);
+        if (seat == null || !seat.getEventId().equals(eventId)) {
+            throw new IllegalStateException("Seat not found");
+        }
+        return seat;
+    }
+
+    public Seat cancelSeat(Long eventId, Long seatId) {
+        Seat seat = seatRepository.findById(seatId);
+        if (seat == null || !seat.getEventId().equals(eventId) || !seat.isReserved()) {
+            throw new IllegalStateException("Seat not reserved");
+        }
+        seat.setReserved(false);
+        seatRepository.save(seat);
+        Ticket ticket = ticketRepository.findByEventIdAndSeatId(eventId, seatId);
+        if (ticket != null) {
+            ticketRepository.delete(ticket.getId());
+        }
+        return seat;
+    }
+
+    public List<Ticket> getTicketsForCustomer(String customer) {
+        return ticketRepository.findByCustomer(customer);
+    }
+
+    public void cancelTicket(Long ticketId, String customer) {
+        Ticket ticket = ticketRepository.findById(ticketId);
+        if (ticket == null || !customer.equals(ticket.getCustomer())) {
+            throw new IllegalStateException("Ticket not found");
+        }
+        Seat seat = seatRepository.findById(ticket.getSeatId());
+        if (seat != null) {
+            seat.setReserved(false);
+            seatRepository.save(seat);
+        }
+        ticketRepository.delete(ticketId);
+    }
+}

--- a/src/main/java/com/example/ticketing/web/ReservationController.java
+++ b/src/main/java/com/example/ticketing/web/ReservationController.java
@@ -1,0 +1,46 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.service.ReservationService;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    public ReservationController(ReservationService reservationService) {
+        this.reservationService = reservationService;
+    }
+
+    @PostMapping("/events/{eventId}/seats/{seatId}/reserve")
+    public Ticket reserveSeat(@PathVariable Long eventId,
+                              @PathVariable Long seatId,
+                              Authentication authentication) {
+        return reservationService.reserveSeat(eventId, seatId, authentication.getName());
+    }
+
+    @GetMapping("/events/{eventId}/seats/{seatId}")
+    public Seat getSeat(@PathVariable Long eventId,
+                        @PathVariable Long seatId) {
+        return reservationService.getSeat(eventId, seatId);
+    }
+
+    @PostMapping("/events/{eventId}/seats/{seatId}/cancel")
+    public Seat cancelSeat(@PathVariable Long eventId,
+                           @PathVariable Long seatId) {
+        return reservationService.cancelSeat(eventId, seatId);
+    }
+
+    @GetMapping("/me/tickets")
+    public java.util.List<Ticket> myTickets(Authentication authentication) {
+        return reservationService.getTicketsForCustomer(authentication.getName());
+    }
+
+    @DeleteMapping("/me/tickets/{ticketId}")
+    public void cancelMyTicket(@PathVariable Long ticketId, Authentication authentication) {
+        reservationService.cancelTicket(ticketId, authentication.getName());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.main.banner-mode=off

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Ticket Reservation</title>
+</head>
+<body>
+<h1>Login</h1>
+<form id="loginForm">
+    <label>Username: <input type="text" id="username" required></label><br>
+    <label>Password: <input type="password" id="password" required></label><br>
+    <button type="submit">Login</button>
+</form>
+<pre id="loginResult"></pre>
+
+<h2>Reserve a Seat</h2>
+<form id="reservationForm">
+    <label>Event ID: <input type="number" id="eventId" required></label><br>
+    <label>Seat ID: <input type="number" id="seatId" required></label><br>
+    <button type="submit">Reserve</button>
+</form>
+<pre id="result"></pre>
+
+<h2>Check Seat</h2>
+<form id="checkForm">
+    <label>Event ID: <input type="number" id="checkEventId" required></label><br>
+    <label>Seat ID: <input type="number" id="checkSeatId" required></label><br>
+    <button type="submit">Check</button>
+    </form>
+<pre id="checkResult"></pre>
+
+<h2>Cancel Reservation</h2>
+<form id="cancelForm">
+    <label>Event ID: <input type="number" id="cancelEventId" required></label><br>
+    <label>Seat ID: <input type="number" id="cancelSeatId" required></label><br>
+    <button type="submit">Cancel</button>
+</form>
+<pre id="cancelResult"></pre>
+
+<h2>My Tickets</h2>
+<button id="listTickets">List My Tickets</button>
+<pre id="ticketsResult"></pre>
+
+<h2>Cancel My Ticket</h2>
+<form id="cancelTicketForm">
+    <label>Ticket ID: <input type="number" id="ticketId" required></label><br>
+    <button type="submit">Cancel Ticket</button>
+</form>
+<pre id="cancelTicketResult"></pre>
+<script>
+let authHeader = '';
+
+document.getElementById('loginForm').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const user = document.getElementById('username').value;
+    const pass = document.getElementById('password').value;
+    authHeader = 'Basic ' + btoa(user + ':' + pass);
+    document.getElementById('loginResult').textContent = 'Logged in as ' + user;
+});
+
+document.getElementById('reservationForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const eventId = document.getElementById('eventId').value;
+    const seatId = document.getElementById('seatId').value;
+    const result = document.getElementById('result');
+    result.textContent = 'Reserving...';
+    try {
+        const response = await fetch(`/events/${eventId}/seats/${seatId}/reserve`, {
+            method: 'POST',
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const ticket = await response.json();
+        result.textContent = JSON.stringify(ticket, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('checkForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const eventId = document.getElementById('checkEventId').value;
+    const seatId = document.getElementById('checkSeatId').value;
+    const result = document.getElementById('checkResult');
+    result.textContent = 'Checking...';
+    try {
+        const response = await fetch(`/events/${eventId}/seats/${seatId}`, {
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const seat = await response.json();
+        result.textContent = JSON.stringify(seat, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('cancelForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const eventId = document.getElementById('cancelEventId').value;
+    const seatId = document.getElementById('cancelSeatId').value;
+    const result = document.getElementById('cancelResult');
+    result.textContent = 'Cancelling...';
+    try {
+        const response = await fetch(`/events/${eventId}/seats/${seatId}/cancel`, {
+            method: 'POST',
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const seat = await response.json();
+        result.textContent = JSON.stringify(seat, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('listTickets').addEventListener('click', async function() {
+    const result = document.getElementById('ticketsResult');
+    result.textContent = 'Loading...';
+    try {
+        const response = await fetch('/me/tickets', {
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const tickets = await response.json();
+        result.textContent = JSON.stringify(tickets, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('cancelTicketForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const ticketId = document.getElementById('ticketId').value;
+    const result = document.getElementById('cancelTicketResult');
+    result.textContent = 'Cancelling...';
+    try {
+        const response = await fetch(`/me/tickets/${ticketId}`, {
+            method: 'DELETE',
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        result.textContent = 'Cancelled';
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+</script>
+</body>
+</html>

--- a/src/test/java/com/example/ticketing/TicketingApplicationTests.java
+++ b/src/test/java/com/example/ticketing/TicketingApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.ticketing;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TicketingApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/example/ticketing/service/ReservationServiceTest.java
+++ b/src/test/java/com/example/ticketing/service/ReservationServiceTest.java
@@ -1,0 +1,97 @@
+package com.example.ticketing.service;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.repository.SeatRepository;
+import com.example.ticketing.repository.TicketRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @Mock
+    private SeatRepository seatRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(seatRepository, ticketRepository);
+    }
+
+    @Test
+    void reserveSeatSuccessful() {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        Ticket ticket = reservationService.reserveSeat(1L, 1L, "Alice");
+
+        assertNotNull(ticket.getId());
+        assertEquals(1L, ticket.getEventId());
+        assertEquals(1L, ticket.getSeatId());
+        assertEquals("Alice", ticket.getCustomer());
+
+        ArgumentCaptor<Seat> seatCaptor = ArgumentCaptor.forClass(Seat.class);
+        verify(seatRepository).save(seatCaptor.capture());
+        assertTrue(seatCaptor.getValue().isReserved());
+
+        verify(ticketRepository).save(ticket);
+    }
+
+    @Test
+    void reserveAlreadyReservedSeatThrows() {
+        Seat seat = new Seat(1L, 1L, "A1", true);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        assertThrows(IllegalStateException.class, () -> reservationService.reserveSeat(1L, 1L, "Alice"));
+
+        verify(seatRepository, never()).save(any());
+        verify(ticketRepository, never()).save(any());
+    }
+
+    @Test
+    void reserveSeatWithWrongEventIdThrows() {
+        Seat seat = new Seat(1L, 2L, "A1", false);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        assertThrows(IllegalStateException.class, () -> reservationService.reserveSeat(1L, 1L, "Alice"));
+
+        verify(seatRepository, never()).save(any());
+        verify(ticketRepository, never()).save(any());
+    }
+
+    @Test
+    void cancelSeatSuccessful() {
+        Seat seat = new Seat(1L, 1L, "A1", true);
+        Ticket ticket = new Ticket(5L, 1L, 1L, "Alice");
+        when(seatRepository.findById(1L)).thenReturn(seat);
+        when(ticketRepository.findByEventIdAndSeatId(1L, 1L)).thenReturn(ticket);
+
+        Seat result = reservationService.cancelSeat(1L, 1L);
+
+        assertFalse(result.isReserved());
+        verify(seatRepository).save(seat);
+        verify(ticketRepository).delete(5L);
+    }
+
+    @Test
+    void cancelSeatNotReservedThrows() {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        assertThrows(IllegalStateException.class, () -> reservationService.cancelSeat(1L, 1L));
+
+        verify(seatRepository, never()).save(any());
+        verify(ticketRepository, never()).delete(anyLong());
+    }
+}

--- a/src/test/java/com/example/ticketing/web/ReservationControllerTest.java
+++ b/src/test/java/com/example/ticketing/web/ReservationControllerTest.java
@@ -1,0 +1,83 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.service.ReservationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ReservationController.class)
+@Import(com.example.ticketing.config.SecurityConfig.class)
+class ReservationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReservationService reservationService;
+
+    @Test
+    void reserveSeatReturnsTicket() throws Exception {
+        Ticket ticket = new Ticket(1L, 1L, 1L, "user");
+        when(reservationService.reserveSeat(1L, 1L, "user")).thenReturn(ticket);
+
+        mockMvc.perform(post("/events/1/seats/1/reserve")
+                .with(httpBasic("user", "password"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventId").value(1L))
+                .andExpect(jsonPath("$.seatId").value(1L))
+                .andExpect(jsonPath("$.customer").value("user"));
+    }
+
+    @Test
+    void reserveSeatReturnsError() throws Exception {
+        when(reservationService.reserveSeat(1L, 1L, "user"))
+                .thenThrow(new IllegalStateException("Seat not available"));
+
+        mockMvc.perform(post("/events/1/seats/1/reserve")
+                .with(httpBasic("user", "password"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void getSeatReturnsSeat() throws Exception {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(reservationService.getSeat(1L, 1L)).thenReturn(seat);
+
+        mockMvc.perform(get("/events/1/seats/1").with(httpBasic("user", "password")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.reserved").value(false));
+    }
+
+    @Test
+    void cancelSeatReturnsSeat() throws Exception {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(reservationService.cancelSeat(1L, 1L)).thenReturn(seat);
+
+        mockMvc.perform(post("/events/1/seats/1/cancel").with(httpBasic("user", "password")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reserved").value(false));
+    }
+
+    @Test
+    void cancelSeatReturnsError() throws Exception {
+        when(reservationService.cancelSeat(1L, 1L)).thenThrow(new IllegalStateException("Seat not reserved"));
+
+        mockMvc.perform(post("/events/1/seats/1/cancel").with(httpBasic("user", "password")))
+                .andExpect(status().isInternalServerError());
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold Spring Boot project with Apache Ignite configuration
- add models for events, seats and tickets with Ignite-backed repositories
- implement reservation service and REST controller for seat reservations
- load demo event and seats at startup and serve a simple HTML page for manual seat reservations
- add unit tests for reservation service and controller
- document prerequisites, run instructions and example REST call in README
- clarify required JVM options and align project with Spring Boot 2.7.18
- note manual ID caution in `DataInitializer`
- add seat status check and cancellation endpoints with front-end forms
- document tech stack and project structure in README
- secure endpoints with HTTP basic auth and allow users to list and cancel their own tickets

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:ticketing-ignite:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM @ line 5, column 13)*

------
https://chatgpt.com/codex/tasks/task_e_68961b4f4b04832098acfb1c9b5c2fa9