### PR TITLE
Add persistent user registration and admin account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,114 @@
 # Ticket_IGNITE
-Ticket system with Apache Ignite distributed system.
+
+Proof-of-concept ticketing service that uses Apache Ignite as a
+distributed data store.
+
+## Tech stack
+
+- Java 17
+- Spring Boot 2.7.18
+- Apache Ignite 2.15
+- REST + JSON
+- HTTP Basic authentication
+- Maven for build
+- JUnit 5 for tests
+
+## Project structure
+
+```text
+ticketing-ignite/
+├── pom.xml
+└── src
+    ├── main/java/com/example/ticketing
+    │   ├── TicketingApplication.java
+    │   ├── config/
+    │   ├── model/
+    │   ├── repository/
+    │   ├── service/
+    │   └── web/
+    └── test/java/com/example/ticketing
+        ├── service/
+        └── web/
+```
+
+## Prerequisites
+
+- Java 17+
+- Maven 3+
+
+## Running the application
+
+1. Start the Spring Boot application, which will also start an embedded
+   Ignite node:
+
+   ```bash
+   mvn spring-boot:run -Dspring-boot.run.jvmArguments="\
+   --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
+   --add-opens=java.base/java.nio=ALL-UNNAMED \
+   --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
+   --add-opens=java.base/java.lang=ALL-UNNAMED \
+   --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+   --add-opens=java.base/java.util=ALL-UNNAMED \
+   --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
+   --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
+   --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
+   -Djava.net.preferIPv4Stack=true \
+   -Xms512m -Xmx512m"
+   ```
+
+2. Sample data for one demo event with two seats is loaded at startup. A default admin user (`admin` / `admin`) is created. Register a regular account before accessing user endpoints:
+
+   ```bash
+   curl -H "Content-Type: application/json" -d '{"username":"user","password":"password"}' http://localhost:8080/register
+   ```
+
+   Reserve a seat:
+
+   ```bash
+   curl -u user:password -X POST "http://localhost:8080/events/1/seats/1/reserve"
+   ```
+
+   List your tickets:
+
+   ```bash
+   curl -u user:password "http://localhost:8080/me/tickets"
+   ```
+
+   Cancel a ticket:
+
+   ```bash
+   curl -u user:password -X DELETE "http://localhost:8080/me/tickets/{ticketId}"
+   ```
+
+   On success, the service returns a JSON representation of the seat or
+   ticket. Invalid operations yield an error response.
+
+   Admin endpoints allow creating events and managing seats:
+
+   ```bash
+   curl -u admin:admin -H "Content-Type: application/json" \
+     -d '{"name":"Concert","seatCount":5}' \
+     -X POST "http://localhost:8080/admin/events"
+
+   curl -u admin:admin "http://localhost:8080/admin/events/1/seats"
+
+   curl -u admin:admin -H "Content-Type: application/json" \
+     -d '{"reserved":false}' -X PUT "http://localhost:8080/admin/seats/{seatId}"
+   ```
+
+3. A simple web page is available for manual testing:
+
+   ```
+   http://localhost:8080/index.html
+   ```
+
+   Use the login form first, then manage reservations through the provided
+   forms to reserve seats, view your tickets and cancel them.
+
+## Running tests
+
+```bash
+mvn test
+```
+
+The tests cover the reservation service and the REST controller.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.18</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>ticketing-ignite</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>ticketing-ignite</name>
+    <description>Ticket system with Apache Ignite</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-core</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ignite</groupId>
+            <artifactId>ignite-spring</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/ticketing/TicketingApplication.java
+++ b/src/main/java/com/example/ticketing/TicketingApplication.java
@@ -1,0 +1,11 @@
+package com.example.ticketing;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TicketingApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TicketingApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/ticketing/config/DataInitializer.java
+++ b/src/main/java/com/example/ticketing/config/DataInitializer.java
@@ -1,0 +1,42 @@
+package com.example.ticketing.config;
+
+import com.example.ticketing.model.Event;
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.User;
+import com.example.ticketing.repository.EventRepository;
+import com.example.ticketing.repository.SeatRepository;
+import com.example.ticketing.repository.UserRepository;
+import javax.annotation.PostConstruct;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataInitializer {
+    private final EventRepository eventRepository;
+    private final SeatRepository seatRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public DataInitializer(EventRepository eventRepository, SeatRepository seatRepository,
+                           UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.eventRepository = eventRepository;
+        this.seatRepository = seatRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PostConstruct
+    public void init() {
+        if (userRepository.findByUsername("admin") == null) {
+            User admin = new User(userRepository.nextId(), "admin", passwordEncoder.encode("admin"), "ADMIN");
+            userRepository.save(admin);
+        }
+
+        long eventId = eventRepository.nextId();
+        Event event = new Event(eventId, "Demo Event");
+        eventRepository.save(event);
+
+        seatRepository.save(new Seat(seatRepository.nextId(), eventId, "A1", false));
+        seatRepository.save(new Seat(seatRepository.nextId(), eventId, "A2", false));
+    }
+}

--- a/src/main/java/com/example/ticketing/config/IgniteConfig.java
+++ b/src/main/java/com/example/ticketing/config/IgniteConfig.java
@@ -1,0 +1,19 @@
+package com.example.ticketing.config;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class IgniteConfig {
+
+    @Bean(destroyMethod = "close")
+    public Ignite ignite() {
+        IgniteConfiguration cfg = new IgniteConfiguration();
+        cfg.setIgniteInstanceName("ticketing-ignite");
+        cfg.setPeerClassLoadingEnabled(true);
+        return Ignition.start(cfg);
+    }
+}

--- a/src/main/java/com/example/ticketing/config/SecurityConfig.java
+++ b/src/main/java/com/example/ticketing/config/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.example.ticketing.config;
+
+import com.example.ticketing.model.User;
+import com.example.ticketing.repository.UserRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final UserRepository userRepository;
+
+    public SecurityConfig(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeRequests()
+                .antMatchers("/admin/**").hasRole("ADMIN")
+                .antMatchers("/register").permitAll()
+                .anyRequest().authenticated()
+            .and().httpBasic();
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return username -> {
+            User user = userRepository.findByUsername(username);
+            if (user == null) {
+                throw new UsernameNotFoundException("User not found");
+            }
+            UserDetails details = org.springframework.security.core.userdetails.User
+                    .withUsername(user.getUsername())
+                    .password(user.getPassword())
+                    .roles(user.getRole())
+                    .build();
+            return details;
+        };
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/ticketing/model/Event.java
+++ b/src/main/java/com/example/ticketing/model/Event.java
@@ -1,0 +1,32 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class Event implements Serializable {
+    private Long id;
+    private String name;
+
+    public Event() {
+    }
+
+    public Event(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/ticketing/model/Seat.java
+++ b/src/main/java/com/example/ticketing/model/Seat.java
@@ -1,0 +1,52 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class Seat implements Serializable {
+    private Long id;
+    private Long eventId;
+    private String number;
+    private boolean reserved;
+
+    public Seat() {
+    }
+
+    public Seat(Long id, Long eventId, String number, boolean reserved) {
+        this.id = id;
+        this.eventId = eventId;
+        this.number = number;
+        this.reserved = reserved;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Long eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public boolean isReserved() {
+        return reserved;
+    }
+
+    public void setReserved(boolean reserved) {
+        this.reserved = reserved;
+    }
+}

--- a/src/main/java/com/example/ticketing/model/Ticket.java
+++ b/src/main/java/com/example/ticketing/model/Ticket.java
@@ -1,0 +1,52 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class Ticket implements Serializable {
+    private Long id;
+    private Long eventId;
+    private Long seatId;
+    private String customer;
+
+    public Ticket() {
+    }
+
+    public Ticket(Long id, Long eventId, Long seatId, String customer) {
+        this.id = id;
+        this.eventId = eventId;
+        this.seatId = seatId;
+        this.customer = customer;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(Long eventId) {
+        this.eventId = eventId;
+    }
+
+    public Long getSeatId() {
+        return seatId;
+    }
+
+    public void setSeatId(Long seatId) {
+        this.seatId = seatId;
+    }
+
+    public String getCustomer() {
+        return customer;
+    }
+
+    public void setCustomer(String customer) {
+        this.customer = customer;
+    }
+}

--- a/src/main/java/com/example/ticketing/model/User.java
+++ b/src/main/java/com/example/ticketing/model/User.java
@@ -1,0 +1,51 @@
+package com.example.ticketing.model;
+
+import java.io.Serializable;
+
+public class User implements Serializable {
+    private Long id;
+    private String username;
+    private String password;
+    private String role;
+
+    public User() {}
+
+    public User(Long id, String username, String password, String role) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/EventRepository.java
+++ b/src/main/java/com/example/ticketing/repository/EventRepository.java
@@ -1,0 +1,41 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.Event;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.atomic.IgniteAtomicSequence;
+import org.apache.ignite.cache.query.ScanQuery;
+import javax.cache.Cache;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EventRepository {
+
+    private final IgniteCache<Long, Event> cache;
+    private final IgniteAtomicSequence idSeq;
+
+    public EventRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("events");
+        this.idSeq = ignite.atomicSequence("eventIds", 0, true);
+    }
+
+    public void save(Event event) {
+        cache.put(event.getId(), event);
+    }
+
+    public Event findById(Long id) {
+        return cache.get(id);
+    }
+
+    public long nextId() {
+        return idSeq.incrementAndGet();
+    }
+
+    public List<Event> findAll() {
+        return cache.query(new ScanQuery<Long, Event>()).getAll().stream()
+                .map(Cache.Entry::getValue)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/SeatRepository.java
+++ b/src/main/java/com/example/ticketing/repository/SeatRepository.java
@@ -1,0 +1,42 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.Seat;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.atomic.IgniteAtomicSequence;
+import org.apache.ignite.cache.query.ScanQuery;
+import javax.cache.Cache;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SeatRepository {
+
+    private final IgniteCache<Long, Seat> cache;
+    private final IgniteAtomicSequence idSeq;
+
+    public SeatRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("seats");
+        this.idSeq = ignite.atomicSequence("seatIds", 0, true);
+    }
+
+    public void save(Seat seat) {
+        cache.put(seat.getId(), seat);
+    }
+
+    public Seat findById(Long id) {
+        return cache.get(id);
+    }
+
+    public long nextId() {
+        return idSeq.incrementAndGet();
+    }
+
+    public List<Seat> findByEventId(Long eventId) {
+        return cache.query(new ScanQuery<Long, Seat>((k, v) -> v.getEventId().equals(eventId)))
+                .getAll().stream()
+                .map(Cache.Entry::getValue)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/TicketRepository.java
+++ b/src/main/java/com/example/ticketing/repository/TicketRepository.java
@@ -1,0 +1,53 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.Ticket;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.springframework.stereotype.Repository;
+
+import javax.cache.Cache;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class TicketRepository {
+
+    private final IgniteCache<Long, Ticket> cache;
+
+    public TicketRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("tickets");
+    }
+
+    public void save(Ticket ticket) {
+        cache.put(ticket.getId(), ticket);
+    }
+
+    public Ticket findById(Long id) {
+        return cache.get(id);
+    }
+
+    public void delete(Long id) {
+        cache.remove(id);
+    }
+
+    public Ticket findByEventIdAndSeatId(Long eventId, Long seatId) {
+        for (Cache.Entry<Long, Ticket> entry : cache) {
+            Ticket ticket = entry.getValue();
+            if (ticket.getEventId().equals(eventId) && ticket.getSeatId().equals(seatId)) {
+                return ticket;
+            }
+        }
+        return null;
+    }
+
+    public List<Ticket> findByCustomer(String customer) {
+        List<Ticket> tickets = new ArrayList<>();
+        for (Cache.Entry<Long, Ticket> entry : cache) {
+            Ticket ticket = entry.getValue();
+            if (customer.equals(ticket.getCustomer())) {
+                tickets.add(ticket);
+            }
+        }
+        return tickets;
+    }
+}

--- a/src/main/java/com/example/ticketing/repository/UserRepository.java
+++ b/src/main/java/com/example/ticketing/repository/UserRepository.java
@@ -1,0 +1,37 @@
+package com.example.ticketing.repository;
+
+import com.example.ticketing.model.User;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.atomic.IgniteAtomicSequence;
+import org.apache.ignite.cache.query.ScanQuery;
+import org.springframework.stereotype.Repository;
+
+import javax.cache.Cache;
+import java.util.List;
+
+@Repository
+public class UserRepository {
+
+    private final IgniteCache<Long, User> cache;
+    private final IgniteAtomicSequence idSeq;
+
+    public UserRepository(Ignite ignite) {
+        this.cache = ignite.getOrCreateCache("users");
+        this.idSeq = ignite.atomicSequence("userIds", 0, true);
+    }
+
+    public long nextId() {
+        return idSeq.incrementAndGet();
+    }
+
+    public void save(User user) {
+        cache.put(user.getId(), user);
+    }
+
+    public User findByUsername(String username) {
+        List<Cache.Entry<Long, User>> entries =
+                cache.query(new ScanQuery<Long, User>((k, v) -> username.equals(v.getUsername()))).getAll();
+        return entries.isEmpty() ? null : entries.get(0).getValue();
+    }
+}

--- a/src/main/java/com/example/ticketing/service/AdminService.java
+++ b/src/main/java/com/example/ticketing/service/AdminService.java
@@ -1,0 +1,45 @@
+package com.example.ticketing.service;
+
+import com.example.ticketing.model.Event;
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.repository.EventRepository;
+import com.example.ticketing.repository.SeatRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AdminService {
+    private final EventRepository eventRepository;
+    private final SeatRepository seatRepository;
+
+    public AdminService(EventRepository eventRepository, SeatRepository seatRepository) {
+        this.eventRepository = eventRepository;
+        this.seatRepository = seatRepository;
+    }
+
+    public Event createEvent(String name, int seatCount) {
+        long eventId = eventRepository.nextId();
+        Event event = new Event(eventId, name);
+        eventRepository.save(event);
+        for (int i = 1; i <= seatCount; i++) {
+            long seatId = seatRepository.nextId();
+            String number = "A" + i;
+            seatRepository.save(new Seat(seatId, eventId, number, false));
+        }
+        return event;
+    }
+
+    public List<Seat> listSeats(Long eventId) {
+        return seatRepository.findByEventId(eventId);
+    }
+
+    public Seat updateSeat(Long seatId, boolean reserved) {
+        Seat seat = seatRepository.findById(seatId);
+        if (seat != null) {
+            seat.setReserved(reserved);
+            seatRepository.save(seat);
+        }
+        return seat;
+    }
+}

--- a/src/main/java/com/example/ticketing/service/ReservationService.java
+++ b/src/main/java/com/example/ticketing/service/ReservationService.java
@@ -1,0 +1,78 @@
+package com.example.ticketing.service;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.repository.SeatRepository;
+import com.example.ticketing.repository.TicketRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ReservationService {
+
+    private final SeatRepository seatRepository;
+    private final TicketRepository ticketRepository;
+
+    public ReservationService(SeatRepository seatRepository, TicketRepository ticketRepository) {
+        this.seatRepository = seatRepository;
+        this.ticketRepository = ticketRepository;
+    }
+
+    public Ticket reserveSeat(Long eventId, Long seatId, String customer) {
+        Seat seat = seatRepository.findById(seatId);
+        if (seat == null || !seat.getEventId().equals(eventId) || seat.isReserved()) {
+            throw new IllegalStateException("Seat not available");
+        }
+        seat.setReserved(true);
+        seatRepository.save(seat);
+
+        Ticket ticket = new Ticket();
+        ticket.setId(UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE);
+        ticket.setEventId(eventId);
+        ticket.setSeatId(seatId);
+        ticket.setCustomer(customer);
+        ticketRepository.save(ticket);
+        return ticket;
+    }
+
+    public Seat getSeat(Long eventId, Long seatId) {
+        Seat seat = seatRepository.findById(seatId);
+        if (seat == null || !seat.getEventId().equals(eventId)) {
+            throw new IllegalStateException("Seat not found");
+        }
+        return seat;
+    }
+
+    public Seat cancelSeat(Long eventId, Long seatId) {
+        Seat seat = seatRepository.findById(seatId);
+        if (seat == null || !seat.getEventId().equals(eventId) || !seat.isReserved()) {
+            throw new IllegalStateException("Seat not reserved");
+        }
+        seat.setReserved(false);
+        seatRepository.save(seat);
+        Ticket ticket = ticketRepository.findByEventIdAndSeatId(eventId, seatId);
+        if (ticket != null) {
+            ticketRepository.delete(ticket.getId());
+        }
+        return seat;
+    }
+
+    public List<Ticket> getTicketsForCustomer(String customer) {
+        return ticketRepository.findByCustomer(customer);
+    }
+
+    public void cancelTicket(Long ticketId, String customer) {
+        Ticket ticket = ticketRepository.findById(ticketId);
+        if (ticket == null || !customer.equals(ticket.getCustomer())) {
+            throw new IllegalStateException("Ticket not found");
+        }
+        Seat seat = seatRepository.findById(ticket.getSeatId());
+        if (seat != null) {
+            seat.setReserved(false);
+            seatRepository.save(seat);
+        }
+        ticketRepository.delete(ticketId);
+    }
+}

--- a/src/main/java/com/example/ticketing/web/AdminController.java
+++ b/src/main/java/com/example/ticketing/web/AdminController.java
@@ -1,0 +1,66 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.Event;
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.service.AdminService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+    private final AdminService adminService;
+
+    public AdminController(AdminService adminService) {
+        this.adminService = adminService;
+    }
+
+    public static class CreateEventRequest {
+        private String name;
+        private int seatCount;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getSeatCount() {
+            return seatCount;
+        }
+
+        public void setSeatCount(int seatCount) {
+            this.seatCount = seatCount;
+        }
+    }
+
+    public static class SeatUpdateRequest {
+        private boolean reserved;
+
+        public boolean isReserved() {
+            return reserved;
+        }
+
+        public void setReserved(boolean reserved) {
+            this.reserved = reserved;
+        }
+    }
+
+    @PostMapping("/events")
+    public Event createEvent(@RequestBody CreateEventRequest request) {
+        return adminService.createEvent(request.getName(), request.getSeatCount());
+    }
+
+    @GetMapping("/events/{eventId}/seats")
+    public List<Seat> listSeats(@PathVariable Long eventId) {
+        return adminService.listSeats(eventId);
+    }
+
+    @PutMapping("/seats/{seatId}")
+    public Seat updateSeat(@PathVariable Long seatId, @RequestBody SeatUpdateRequest request) {
+        return adminService.updateSeat(seatId, request.isReserved());
+    }
+}

--- a/src/main/java/com/example/ticketing/web/ReservationController.java
+++ b/src/main/java/com/example/ticketing/web/ReservationController.java
@@ -1,0 +1,46 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.service.ReservationService;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    public ReservationController(ReservationService reservationService) {
+        this.reservationService = reservationService;
+    }
+
+    @PostMapping("/events/{eventId}/seats/{seatId}/reserve")
+    public Ticket reserveSeat(@PathVariable Long eventId,
+                              @PathVariable Long seatId,
+                              Authentication authentication) {
+        return reservationService.reserveSeat(eventId, seatId, authentication.getName());
+    }
+
+    @GetMapping("/events/{eventId}/seats/{seatId}")
+    public Seat getSeat(@PathVariable Long eventId,
+                        @PathVariable Long seatId) {
+        return reservationService.getSeat(eventId, seatId);
+    }
+
+    @PostMapping("/events/{eventId}/seats/{seatId}/cancel")
+    public Seat cancelSeat(@PathVariable Long eventId,
+                           @PathVariable Long seatId) {
+        return reservationService.cancelSeat(eventId, seatId);
+    }
+
+    @GetMapping("/me/tickets")
+    public java.util.List<Ticket> myTickets(Authentication authentication) {
+        return reservationService.getTicketsForCustomer(authentication.getName());
+    }
+
+    @DeleteMapping("/me/tickets/{ticketId}")
+    public void cancelMyTicket(@PathVariable Long ticketId, Authentication authentication) {
+        reservationService.cancelTicket(ticketId, authentication.getName());
+    }
+}

--- a/src/main/java/com/example/ticketing/web/UserController.java
+++ b/src/main/java/com/example/ticketing/web/UserController.java
@@ -1,0 +1,34 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.User;
+import com.example.ticketing.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+@RestController
+public class UserController {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserController(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody Map<String, String> body) {
+        String username = body.get("username");
+        String password = body.get("password");
+        if (userRepository.findByUsername(username) != null) {
+            return ResponseEntity.badRequest().body("User exists");
+        }
+        User user = new User(userRepository.nextId(), username, passwordEncoder.encode(password), "USER");
+        userRepository.save(user);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.main.banner-mode=off

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Ticket Reservation</title>
+</head>
+<body>
+<h1>Register</h1>
+<form id="registerForm">
+    <label>Username: <input type="text" id="regUsername" required></label><br>
+    <label>Password: <input type="password" id="regPassword" required></label><br>
+    <button type="submit">Register</button>
+</form>
+<pre id="registerResult"></pre>
+
+<h1>Login</h1>
+<form id="loginForm">
+    <label>Username: <input type="text" id="username" required></label><br>
+    <label>Password: <input type="password" id="password" required></label><br>
+    <button type="submit">Login</button>
+</form>
+<pre id="loginResult"></pre>
+
+<h2>Reserve a Seat</h2>
+<form id="reservationForm">
+    <label>Event ID: <input type="number" id="eventId" required></label><br>
+    <label>Seat ID: <input type="number" id="seatId" required></label><br>
+    <button type="submit">Reserve</button>
+</form>
+<pre id="result"></pre>
+
+<h2>Check Seat</h2>
+<form id="checkForm">
+    <label>Event ID: <input type="number" id="checkEventId" required></label><br>
+    <label>Seat ID: <input type="number" id="checkSeatId" required></label><br>
+    <button type="submit">Check</button>
+    </form>
+<pre id="checkResult"></pre>
+
+<h2>Cancel Reservation</h2>
+<form id="cancelForm">
+    <label>Event ID: <input type="number" id="cancelEventId" required></label><br>
+    <label>Seat ID: <input type="number" id="cancelSeatId" required></label><br>
+    <button type="submit">Cancel</button>
+</form>
+<pre id="cancelResult"></pre>
+
+<h2>My Tickets</h2>
+<button id="listTickets">List My Tickets</button>
+<pre id="ticketsResult"></pre>
+
+<h2>Cancel My Ticket</h2>
+<form id="cancelTicketForm">
+    <label>Ticket ID: <input type="number" id="ticketId" required></label><br>
+    <button type="submit">Cancel Ticket</button>
+</form>
+<pre id="cancelTicketResult"></pre>
+
+<h2>Admin: Create Event</h2>
+<form id="createEventForm">
+    <label>Name: <input type="text" id="eventName" required></label><br>
+    <label>Seats: <input type="number" id="seatCount" required></label><br>
+    <button type="submit">Create</button>
+    </form>
+<pre id="createEventResult"></pre>
+
+<h2>Admin: List Seats</h2>
+<form id="listSeatsForm">
+    <label>Event ID: <input type="number" id="listEventId" required></label><br>
+    <button type="submit">List</button>
+</form>
+<pre id="listSeatsResult"></pre>
+
+<h2>Admin: Update Seat</h2>
+<form id="updateSeatForm">
+    <label>Seat ID: <input type="number" id="updateSeatId" required></label><br>
+    <label>Reserved: <input type="checkbox" id="updateReserved"></label><br>
+    <button type="submit">Update</button>
+</form>
+<pre id="updateSeatResult"></pre>
+<script>
+let authHeader = '';
+
+document.getElementById("registerForm").addEventListener("submit", async function(e) {
+    e.preventDefault();
+    const user = document.getElementById("regUsername").value;
+    const pass = document.getElementById("regPassword").value;
+    const result = document.getElementById("registerResult");
+    try {
+        const resp = await fetch("/register", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ username: user, password: pass })
+        });
+        if (!resp.ok) {
+            const text = await resp.text();
+            throw new Error(text || resp.status);
+        }
+        result.textContent = "Registered";
+    } catch (err) {
+        result.textContent = "Error: " + err.message;
+    }
+});
+
+document.getElementById('loginForm').addEventListener('submit', function(e) {
+    e.preventDefault();
+    const user = document.getElementById('username').value;
+    const pass = document.getElementById('password').value;
+    authHeader = 'Basic ' + btoa(user + ':' + pass);
+    document.getElementById('loginResult').textContent = 'Logged in as ' + user;
+});
+
+document.getElementById('reservationForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const eventId = document.getElementById('eventId').value;
+    const seatId = document.getElementById('seatId').value;
+    const result = document.getElementById('result');
+    result.textContent = 'Reserving...';
+    try {
+        const response = await fetch(`/events/${eventId}/seats/${seatId}/reserve`, {
+            method: 'POST',
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const ticket = await response.json();
+        result.textContent = JSON.stringify(ticket, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('checkForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const eventId = document.getElementById('checkEventId').value;
+    const seatId = document.getElementById('checkSeatId').value;
+    const result = document.getElementById('checkResult');
+    result.textContent = 'Checking...';
+    try {
+        const response = await fetch(`/events/${eventId}/seats/${seatId}`, {
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const seat = await response.json();
+        result.textContent = JSON.stringify(seat, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('cancelForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const eventId = document.getElementById('cancelEventId').value;
+    const seatId = document.getElementById('cancelSeatId').value;
+    const result = document.getElementById('cancelResult');
+    result.textContent = 'Cancelling...';
+    try {
+        const response = await fetch(`/events/${eventId}/seats/${seatId}/cancel`, {
+            method: 'POST',
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const seat = await response.json();
+        result.textContent = JSON.stringify(seat, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('listTickets').addEventListener('click', async function() {
+    const result = document.getElementById('ticketsResult');
+    result.textContent = 'Loading...';
+    try {
+        const response = await fetch('/me/tickets', {
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const tickets = await response.json();
+        result.textContent = JSON.stringify(tickets, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('cancelTicketForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const ticketId = document.getElementById('ticketId').value;
+    const result = document.getElementById('cancelTicketResult');
+    result.textContent = 'Cancelling...';
+    try {
+        const response = await fetch(`/me/tickets/${ticketId}`, {
+            method: 'DELETE',
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        result.textContent = 'Cancelled';
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('createEventForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const name = document.getElementById('eventName').value;
+    const seats = parseInt(document.getElementById('seatCount').value, 10);
+    const result = document.getElementById('createEventResult');
+    result.textContent = 'Creating...';
+    try {
+        const response = await fetch('/admin/events', {
+            method: 'POST',
+            headers: { 'Authorization': authHeader, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: name, seatCount: seats })
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const event = await response.json();
+        result.textContent = JSON.stringify(event, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('listSeatsForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const eventId = document.getElementById('listEventId').value;
+    const result = document.getElementById('listSeatsResult');
+    result.textContent = 'Loading...';
+    try {
+        const response = await fetch(`/admin/events/${eventId}/seats`, {
+            headers: { 'Authorization': authHeader }
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const seats = await response.json();
+        result.textContent = JSON.stringify(seats, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+
+document.getElementById('updateSeatForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const seatId = document.getElementById('updateSeatId').value;
+    const reserved = document.getElementById('updateReserved').checked;
+    const result = document.getElementById('updateSeatResult');
+    result.textContent = 'Updating...';
+    try {
+        const response = await fetch(`/admin/seats/${seatId}`, {
+            method: 'PUT',
+            headers: { 'Authorization': authHeader, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ reserved: reserved })
+        });
+        if (!response.ok) {
+            const text = await response.text();
+            throw new Error(text || response.status);
+        }
+        const seat = await response.json();
+        result.textContent = JSON.stringify(seat, null, 2);
+    } catch (err) {
+        result.textContent = 'Error: ' + err.message;
+    }
+});
+</script>
+</body>
+</html>

--- a/src/test/java/com/example/ticketing/TicketingApplicationTests.java
+++ b/src/test/java/com/example/ticketing/TicketingApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.ticketing;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TicketingApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/src/test/java/com/example/ticketing/service/AdminServiceTest.java
+++ b/src/test/java/com/example/ticketing/service/AdminServiceTest.java
@@ -1,0 +1,60 @@
+package com.example.ticketing.service;
+
+import com.example.ticketing.model.Event;
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.repository.EventRepository;
+import com.example.ticketing.repository.SeatRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private SeatRepository seatRepository;
+
+    private AdminService adminService;
+
+    @BeforeEach
+    void setUp() {
+        adminService = new AdminService(eventRepository, seatRepository);
+    }
+
+    @Test
+    void createEventGeneratesSeats() {
+        when(eventRepository.nextId()).thenReturn(1L);
+        when(seatRepository.nextId()).thenReturn(1L, 2L);
+
+        Event event = adminService.createEvent("Show", 2);
+
+        assertEquals(1L, event.getId());
+        assertEquals("Show", event.getName());
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventRepository).save(eventCaptor.capture());
+        assertEquals(1L, eventCaptor.getValue().getId());
+
+        verify(seatRepository, times(2)).save(any(Seat.class));
+    }
+
+    @Test
+    void updateSeatChangesReservedStatus() {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        Seat result = adminService.updateSeat(1L, true);
+
+        assertTrue(result.isReserved());
+        verify(seatRepository).save(seat);
+    }
+}

--- a/src/test/java/com/example/ticketing/service/ReservationServiceTest.java
+++ b/src/test/java/com/example/ticketing/service/ReservationServiceTest.java
@@ -1,0 +1,97 @@
+package com.example.ticketing.service;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.repository.SeatRepository;
+import com.example.ticketing.repository.TicketRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @Mock
+    private SeatRepository seatRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(seatRepository, ticketRepository);
+    }
+
+    @Test
+    void reserveSeatSuccessful() {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        Ticket ticket = reservationService.reserveSeat(1L, 1L, "Alice");
+
+        assertNotNull(ticket.getId());
+        assertEquals(1L, ticket.getEventId());
+        assertEquals(1L, ticket.getSeatId());
+        assertEquals("Alice", ticket.getCustomer());
+
+        ArgumentCaptor<Seat> seatCaptor = ArgumentCaptor.forClass(Seat.class);
+        verify(seatRepository).save(seatCaptor.capture());
+        assertTrue(seatCaptor.getValue().isReserved());
+
+        verify(ticketRepository).save(ticket);
+    }
+
+    @Test
+    void reserveAlreadyReservedSeatThrows() {
+        Seat seat = new Seat(1L, 1L, "A1", true);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        assertThrows(IllegalStateException.class, () -> reservationService.reserveSeat(1L, 1L, "Alice"));
+
+        verify(seatRepository, never()).save(any());
+        verify(ticketRepository, never()).save(any());
+    }
+
+    @Test
+    void reserveSeatWithWrongEventIdThrows() {
+        Seat seat = new Seat(1L, 2L, "A1", false);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        assertThrows(IllegalStateException.class, () -> reservationService.reserveSeat(1L, 1L, "Alice"));
+
+        verify(seatRepository, never()).save(any());
+        verify(ticketRepository, never()).save(any());
+    }
+
+    @Test
+    void cancelSeatSuccessful() {
+        Seat seat = new Seat(1L, 1L, "A1", true);
+        Ticket ticket = new Ticket(5L, 1L, 1L, "Alice");
+        when(seatRepository.findById(1L)).thenReturn(seat);
+        when(ticketRepository.findByEventIdAndSeatId(1L, 1L)).thenReturn(ticket);
+
+        Seat result = reservationService.cancelSeat(1L, 1L);
+
+        assertFalse(result.isReserved());
+        verify(seatRepository).save(seat);
+        verify(ticketRepository).delete(5L);
+    }
+
+    @Test
+    void cancelSeatNotReservedThrows() {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(seatRepository.findById(1L)).thenReturn(seat);
+
+        assertThrows(IllegalStateException.class, () -> reservationService.cancelSeat(1L, 1L));
+
+        verify(seatRepository, never()).save(any());
+        verify(ticketRepository, never()).delete(anyLong());
+    }
+}

--- a/src/test/java/com/example/ticketing/web/AdminControllerTest.java
+++ b/src/test/java/com/example/ticketing/web/AdminControllerTest.java
@@ -1,0 +1,81 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.Event;
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.User;
+import com.example.ticketing.repository.UserRepository;
+import com.example.ticketing.service.AdminService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminController.class)
+@Import(com.example.ticketing.config.SecurityConfig.class)
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AdminService adminService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setupUsers() {
+        when(userRepository.findByUsername("admin")).thenReturn(new User(1L, "admin", passwordEncoder.encode("admin"), "ADMIN"));
+        when(userRepository.findByUsername("user")).thenReturn(new User(2L, "user", passwordEncoder.encode("password"), "USER"));
+    }
+
+    @Test
+    void createEventReturnsEvent() throws Exception {
+        Event event = new Event(1L, "Show");
+        when(adminService.createEvent("Show", 2)).thenReturn(event);
+
+        mockMvc.perform(post("/admin/events")
+                .with(httpBasic("admin", "admin"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Show\",\"seatCount\":2}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.name").value("Show"));
+    }
+
+    @Test
+    void createEventRequiresAdmin() throws Exception {
+        mockMvc.perform(post("/admin/events")
+                .with(httpBasic("user", "password"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Show\",\"seatCount\":2}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void updateSeatReturnsSeat() throws Exception {
+        Seat seat = new Seat(1L, 1L, "A1", true);
+        when(adminService.updateSeat(1L, true)).thenReturn(seat);
+
+        mockMvc.perform(put("/admin/seats/1")
+                .with(httpBasic("admin", "admin"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"reserved\":true}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reserved").value(true));
+    }
+}

--- a/src/test/java/com/example/ticketing/web/ReservationControllerTest.java
+++ b/src/test/java/com/example/ticketing/web/ReservationControllerTest.java
@@ -1,0 +1,98 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.Seat;
+import com.example.ticketing.model.Ticket;
+import com.example.ticketing.model.User;
+import com.example.ticketing.repository.UserRepository;
+import com.example.ticketing.service.ReservationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ReservationController.class)
+@Import(com.example.ticketing.config.SecurityConfig.class)
+class ReservationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReservationService reservationService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setupUser() {
+        when(userRepository.findByUsername("user")).thenReturn(new User(1L, "user", passwordEncoder.encode("password"), "USER"));
+    }
+
+    @Test
+    void reserveSeatReturnsTicket() throws Exception {
+        Ticket ticket = new Ticket(1L, 1L, 1L, "user");
+        when(reservationService.reserveSeat(1L, 1L, "user")).thenReturn(ticket);
+
+        mockMvc.perform(post("/events/1/seats/1/reserve")
+                .with(httpBasic("user", "password"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventId").value(1L))
+                .andExpect(jsonPath("$.seatId").value(1L))
+                .andExpect(jsonPath("$.customer").value("user"));
+    }
+
+    @Test
+    void reserveSeatReturnsError() throws Exception {
+        when(reservationService.reserveSeat(1L, 1L, "user"))
+                .thenThrow(new IllegalStateException("Seat not available"));
+
+        mockMvc.perform(post("/events/1/seats/1/reserve")
+                .with(httpBasic("user", "password"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    void getSeatReturnsSeat() throws Exception {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(reservationService.getSeat(1L, 1L)).thenReturn(seat);
+
+        mockMvc.perform(get("/events/1/seats/1").with(httpBasic("user", "password")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.reserved").value(false));
+    }
+
+    @Test
+    void cancelSeatReturnsSeat() throws Exception {
+        Seat seat = new Seat(1L, 1L, "A1", false);
+        when(reservationService.cancelSeat(1L, 1L)).thenReturn(seat);
+
+        mockMvc.perform(post("/events/1/seats/1/cancel").with(httpBasic("user", "password")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reserved").value(false));
+    }
+
+    @Test
+    void cancelSeatReturnsError() throws Exception {
+        when(reservationService.cancelSeat(1L, 1L)).thenThrow(new IllegalStateException("Seat not reserved"));
+
+        mockMvc.perform(post("/events/1/seats/1/cancel").with(httpBasic("user", "password")))
+                .andExpect(status().isInternalServerError());
+    }
+}

--- a/src/test/java/com/example/ticketing/web/UserControllerTest.java
+++ b/src/test/java/com/example/ticketing/web/UserControllerTest.java
@@ -1,0 +1,50 @@
+package com.example.ticketing.web;
+
+import com.example.ticketing.model.User;
+import com.example.ticketing.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@Import(com.example.ticketing.config.SecurityConfig.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Test
+    void registerSuccess() throws Exception {
+        when(userRepository.findByUsername("bob")).thenReturn(null);
+        when(userRepository.nextId()).thenReturn(1L);
+
+        mockMvc.perform(post("/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"bob\",\"password\":\"pw\"}"))
+                .andExpect(status().isOk());
+
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void registerDuplicate() throws Exception {
+        when(userRepository.findByUsername("bob")).thenReturn(new User());
+
+        mockMvc.perform(post("/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"bob\",\"password\":\"pw\"}"))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary
- persist users in Ignite, seed a default admin, and expose a registration endpoint
- back Spring Security with repository-based credentials and permit `/register`
- add registration form to demo page and document signup flow

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.example:ticketing-ignite:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM @ line 5, column 13)*

------
https://chatgpt.com/codex/tasks/task_e_68961b4f4b04832098acfb1c9b5c2fa9