### PR TITLE
Fix IgniteAtomicSequence import path

### DIFF
--- a/src/main/java/com/example/ticketing/repository/EventRepository.java
+++ b/src/main/java/com/example/ticketing/repository/EventRepository.java
@@ -3,7 +3,7 @@ package com.example.ticketing.repository;
 import com.example.ticketing.model.Event;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
-import org.apache.ignite.atomic.IgniteAtomicSequence;
+import org.apache.ignite.IgniteAtomicSequence;
 import org.apache.ignite.cache.query.ScanQuery;
 import javax.cache.Cache;
 import java.util.List;

--- a/src/main/java/com/example/ticketing/repository/SeatRepository.java
+++ b/src/main/java/com/example/ticketing/repository/SeatRepository.java
@@ -3,7 +3,7 @@ package com.example.ticketing.repository;
 import com.example.ticketing.model.Seat;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
-import org.apache.ignite.atomic.IgniteAtomicSequence;
+import org.apache.ignite.IgniteAtomicSequence;
 import org.apache.ignite.cache.query.ScanQuery;
 import javax.cache.Cache;
 import java.util.List;

--- a/src/main/java/com/example/ticketing/repository/UserRepository.java
+++ b/src/main/java/com/example/ticketing/repository/UserRepository.java
@@ -3,7 +3,7 @@ package com.example.ticketing.repository;
 import com.example.ticketing.model.User;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
-import org.apache.ignite.atomic.IgniteAtomicSequence;
+import org.apache.ignite.IgniteAtomicSequence;
 import org.apache.ignite.cache.query.ScanQuery;
 import org.springframework.stereotype.Repository;
 


### PR DESCRIPTION
## Summary
- use org.apache.ignite.IgniteAtomicSequence in repositories

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM ... Network is unreachable)*
- `mvn -e -o test` *(fails: Cannot access central in offline mode and artifact has not been downloaded before)*

------
https://chatgpt.com/codex/tasks/task_e_6899d4f8753883209943e84a31fc09fd